### PR TITLE
pre-calculate half of xy pair

### DIFF
--- a/lib/helpers.c
+++ b/lib/helpers.c
@@ -127,9 +127,9 @@ strlcpy(char *restrict dst,        // O - Destination string
     if (n == 0)
     {
         if (size != 0)
-        *d = '\0';          // NULL-terminate dst
+            *d = '\0';          // NULL-terminate dst
         while (*s++)
-        ;
+            ;
     }
 
     return (s - src - 1);   // count does not include NULL
@@ -222,18 +222,7 @@ bool check_make_dir(char *dirname)
 // Round isn't really included anywhere convenient. input: double, output long
 long bmh_round(double x)
 {
-    long a = (long) x;
-    if (x > 0)
-    {
-        if ((x - a) >= 0.5)
-            a += 1;
-    }
-    else
-    {
-        if ((x - a) <= -0.5)
-            a -= 1;
-    }
-    return (a);
+    return (x > 0) ? (long)(x + 0.5) : (long)(x - 0.5);
 }
 
 //  END math helpers

--- a/recgen/main.c
+++ b/recgen/main.c
@@ -94,9 +94,8 @@ static void internal_singlerec(void *request)
 
     InternalSingleRecResponse message_out = INTERNAL_SINGLE_REC_RESPONSE__INIT;
 
-    // Does the passed-in personid match a user we know about? Checking for >1 b/c personid of 1 has
-    // correct index of 0.
-    if (message_in->personid > 1 && message_in->personid <= BE.num_people && 0 != g_big_rat_index[message_in->personid])
+    // Does the passed-in personid match a user we know about?
+    if (message_in->personid > 0 && message_in->personid <= BE.num_people && 0 != g_big_rat_index[message_in->personid])
     {
         // We can generate recs for this person
         target_id = (int) message_in->elementid;

--- a/recgen/recgen.h
+++ b/recgen/recgen.h
@@ -186,8 +186,9 @@ typedef struct
 {
     exp_elt_t elementid;
     int rating_count;
-    float rating;
-    float rating_accum;
+    int rating;
+// orig    int16_t rating;
+    uint32_t rating_accum;
 } prediction_t;
 
 typedef struct

--- a/test-accuracy/main.c
+++ b/test-accuracy/main.c
@@ -156,6 +156,8 @@ unsigned int random_uint(unsigned int limit)
         unsigned char c[sizeof(unsigned int)];
     } u;
 
+    u.i = 0;
+
     do
     {
         if (!RAND_bytes(u.c, sizeof(u.c)))


### PR DESCRIPTION
<!---
SPDX-FileCopyrightText: 2022 Brian Calhoun <brian@bemorehuman.org>
SPDX-License-Identifier: CC0-1.0
-->
## What does this PR do?
speeds up core by pre-calculating half of the xy pair in tally()

## Github Issue number?
25

## How to test that this PR does what it's supposed to?
- run test-accuracy and see the 30% speed improvement

## Checklist before merging
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests above that prove my fix is effective or that my feature works
- [ x] This PR doesn't break the core accuracy tests
